### PR TITLE
[add]ユーザー一覧データ取得エンドポイント完成

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ SSH URL:
           "userList": [
             {
               "name": "hogeta piyonaka",
-              "groupName": "人事部",
+              "groupNo": 1,  // "人事部"
               "situation": "安否確認中"
             },
             {
               "name": "fugako nakapiyo",
-              "groupName": "情報技術部",
+              "groupNo": 3,  // "情報技術部"
               "situation": "支援必要"
             },,,
           ]
@@ -91,6 +91,17 @@ SSH URL:
       {
         "srvResCode": 7003,                            // コード
         "srvResMsg":  "The condition specification may be correct, but the specified resource cannot be found.", // メッセージ
+        "srvResData": {},                         // データ
+      }
+      ```
+
+  - ステータスコード: 500 Internal Server Error
+    - ボディ:
+
+      ```json
+      {
+        "srvResCode": 7015,                            // コード
+        "srvResMsg":  "Failure to obtain company number.", // メッセージ
         "srvResData": {},                         // データ
       }
       ```
@@ -149,7 +160,7 @@ SSH URL:
       }
       ```
 
-  - ステータスコード: 500 Not Found
+  - ステータスコード: 500 Internal Server Error
     - ボディ:
 
       ```json
@@ -203,7 +214,7 @@ SSH URL:
       ```json
       {
         "srvResCode": 7004,                            // コード
-        "srvResMsg":  "Failed to bind request JSON data.", // メッセージ
+        "srvResMsg":  "Failed to mapping request JSON data.", // メッセージ
         "srvResData": {},                         // データ
       }
       ```
@@ -427,28 +438,30 @@ APIがエラーを返す場合、詳細なエラーメッセージが含まれ�
     リクエストが正しくない。
   - 7003: The condition specification may be correct, but the specified resource cannot be found.  
     条件指定は正しい可能性があるが、指定されたリソースが見つからない。
-  - 7004: Failed to bind request JSON data.  
+  - 7004: Failed to mapping request JSON data.  
     POSTリクエストボディのGO構造体へのバインドが失敗。
   - 7005: The user is already registered.  
     すでにユーザーが登録されている。
-  - 7006: Some problems with db registration of new users.
+  - 7006: Some problems with db registration of new users.  
     新規ユーザのDB登録になんらかの問題が発生した。
-  - 7007: There is already a user with the same primary key. Uniqueness constraint violation.
-    同じ主キーを持つユーザがすでに存在します。一意性制約違反。  
-  - 7008: Authentication unsuccessful. Failed to parse token.
+  - 7007: There is already a user with the same primary key. Uniqueness constraint violation.  
+    同じ主キーを持つユーザがすでに存在します。一意性制約違反。
+  - 7008: Authentication unsuccessful. Failed to parse token.  
     認証に失敗。トークンの解析に失敗。  
   - 7009: User not found.  
     ユーザーが見つからない。  
-  - 7010: Password does not match.
+  - 7010: Password does not match.  
     パスワードが一致しない。
-  - 7011: Failure to obtain user ID.
+  - 7011: Failure to obtain user ID.  
     ユーザIDの取得に失敗。
-  - 7012: Failed to generate authentication token.
+  - 7012: Failed to generate authentication token.  
     認証トークンの生成に失敗。
   - 7013: The id is not stored.  
     トークンから取得したidが保存されていない。
-  - 7014: Failure to retrieve user data.
+  - 7014: Failure to retrieve user data.  
     ユーザデータの取得に失敗。
+  - 7015: Failure to obtain company number.  
+    会社番号の取得に失敗。
 
 ## .ENV
 

--- a/model/kgroup_model.go
+++ b/model/kgroup_model.go
@@ -24,7 +24,7 @@ func CreateKgroupTestData() {
 	db.Create(kg2)
 	kg3 := &Kgroup{
 		KgroupNo:   3, // プライマリーキーを指定しないと自動で作成
-		KgroupName: "開発部",
+		KgroupName: "情報技術部",
 		CompanyNo:  1,
 	}
 	db.Create(kg3)

--- a/model/user_model.go
+++ b/model/user_model.go
@@ -69,7 +69,7 @@ func CfmId(id int) error {
 
 // idからユーザー情報を取得
 func GetUserInfo(id int) (*User, error) {
-	var user User // 取得するユーザデータ
+	var user User // 取得したデータをマッピングする構造体
 	if err := db.Select(
 		"id, name, mail_address, address, situation, company_no, group_no",
 	).First(&user, "id = ?", id).Error; err != nil {
@@ -79,7 +79,7 @@ func GetUserInfo(id int) (*User, error) {
 	// 返り血の方とそれに伴った内部処理。
 	// // idからユーザー情報を取得
 	// func GetUserInfo(id int) (*User, error) {
-	// 	var user User // 取得するユーザデータ
+	// 	var user User // 取得したデータをマッピングする構造体
 	// 	if err := db.Select(
 	// 		"id, name, mail_address, address, situation, company_no, group_no",
 	// 	).First(&user, "id = ?", id).Error; err != nil {
@@ -88,7 +88,7 @@ func GetUserInfo(id int) (*User, error) {
 	// 	return &user, nil
 	// }
 	// // 返り血の型はポインタ変数
-	// // 返り血の型はポインタ変数だが、結果をバインドする変数は構造体で初期化、あとでポインタのみ返す。
+	// // 返り血の型はポインタ変数だが、結果をマッピングする変数は構造体で初期化、あとでポインタのみ返す。
 	// // First()の引数は必ずポインタ
 	// // 返り血の型がポインタ変数なのでnilが返せる。
 	// // 返り血の型がポインタ変数なので最初に作った構造体からポインタを返す。
@@ -96,7 +96,7 @@ func GetUserInfo(id int) (*User, error) {
 	// // idからユーザー情報を取得
 	//
 	//	func GetUserInfo(id int) (User, error) {
-	//		var user User // 取得するユーザデータ
+	//		var user User // 取得したデータをマッピングする構造体
 	//		if err := db.Select(
 	//			"id, name, mail_address, address, situation, company_no, group_no",
 	//		).First(&user, "id = ?", id).Error; err != nil {
@@ -106,20 +106,42 @@ func GetUserInfo(id int) (*User, error) {
 	//	}
 	//
 	// // 返り血の型は構造体のコピー
-	// // 返り血の型は構造体のコピーなので結果をバインドする変数も構造体で初期化。
+	// // 返り血の型は構造体のコピーなので結果をマッピングする変数も構造体で初期化。
 	// // First()の引数は必ずポインタ
 	// // 返り血の型が構造体なのでnilが返せない。
-	// // 返り血の型が構造体なのでバインドされた構造体をそのまま返す。
+	// // 返り血の型が構造体なのでマッピングされた構造体をそのまま返す。
 }
 
 // idから簡易なユーザ情報を取得
 func GetSimpleUserInfo(id int) (*User, error) {
-	var user User // 取得するユーザデータ
+	var user User // 取得したデータをマッピングする構造体
 	if err := db.Select(
-		"id, name, mail_address, address, situation, company_no, group_no",
+		"id, name, mail_address, address, situation, company_no, group_no", // Password以外を取得
 	).First(user, "id = ?", id).Error; err != nil {
 		return nil, err
 	}
 	return &user, nil
 
+}
+
+// user idから所属している会社番号を取得
+func GetCompanyNoById(id int) (int, error) {
+	var user User                                             // 取得したデータをマッピングする構造体
+	if err := db.Select("company_no").First(&user, id).Error; // idに一致するレコードの会社番号のみ取得
+	err != nil {
+		return 0, err
+	}
+	return user.CompanyNo, nil // 会社番号を返す
+}
+
+// 指定された会社番号のユーザー一覧を取得
+func GetUsersDataList(compNo int) ([]User, error) {
+	var users []User // 取得したデータをマッピングする構造体 複数あるのでスライス
+	if err := db.Select(
+		"id, name, mail_address, situation, company_no, group_no", // 最低で名前部署状況は必要
+	).Where("company_no = ?", compNo).Find(&users).Error; // Select(必要な列).Where(会社番号が引数の値).Find(User構造体の形で取得)
+	err != nil {
+		return nil, err
+	}
+	return users, nil // ユーザースライスを返す。
 }

--- a/route/router.go
+++ b/route/router.go
@@ -27,6 +27,8 @@ func GetRouter() (*gin.Engine, error) {
 	engine.POST("/users/login", controller.Login)
 	// get user data
 	engine.GET("/users/user", middleware.MidAuthToken(), controller.UserProfile)
+	// get users data
+	engine.GET("/users/list", middleware.MidAuthToken(), controller.UsersDataList)
 
 	return engine, nil // router設定されたengineを返す。
 }


### PR DESCRIPTION
README.md: ユーザー一覧のレスポンスを会社名ではなく会社番号に変更
router.go: 一覧データ取得エンドポイント追加
kgroup_model.go: テストグループデータ3のKgroupNameを開発部から情報技術部に変更。 メッセージやコメントの「バインド(:bind)」を「マッピング(:mapping)」に変更
コメントの「取得するユーザデータ」を「取得したデータをマッピングする構造体」に変更